### PR TITLE
letの構文解析をした時のASTが把握できるようにテストケースを追加

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,8 +8,9 @@ export type Statement = Node & {
   statementNode: () => void
 }
 
-export type Expression = Node & {
+export interface Expression extends Node {
   expressionNode: () => void
+  token: Token
 }
 
 export class Program {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -58,9 +58,14 @@ export class Parser {
 
     if (!this.expectPeek(TokenType.ASSIGN)) return null
 
-    while (!this.curTokenIs(TokenType.SEMICOLON)) {
-      this.nextToken()
-    }
+    this.nextToken()
+
+    statement.value = new Identifier(
+      this.currentToken,
+      this.currentToken.literal
+    )
+
+    if (!this.expectPeek(TokenType.SEMICOLON)) return null
 
     return statement
   }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -3,6 +3,7 @@ import { Lexer } from '../src/lexer'
 import { Parser } from '../src/parser'
 import { LetStatement, Program } from '../src/ast'
 import type { Statement } from '../src/ast'
+import { TokenType } from 'src/token'
 
 describe('Parser', () => {
   describe('let', () => {
@@ -32,6 +33,51 @@ describe('Parser', () => {
           true
         )
       }
+    })
+    it('should parse let statements into correct AST structure', () => {
+      const expectedResults = [
+        {
+          token: { type: TokenType.LET, literal: 'let' },
+          name: {
+            token: { type: TokenType.IDENT, literal: 'x' },
+            value: 'x',
+          },
+          value: {
+            token: { type: TokenType.INT, literal: '5' },
+            value: '5',
+          },
+        },
+        {
+          token: { type: TokenType.LET, literal: 'let' },
+          name: {
+            token: { type: TokenType.IDENT, literal: 'y' },
+            value: 'y',
+          },
+          value: {
+            token: { type: TokenType.INT, literal: '10' },
+            value: '10',
+          },
+        },
+        {
+          token: { type: TokenType.LET, literal: 'let' },
+          name: {
+            token: { type: TokenType.IDENT, literal: 'foobar' },
+            value: 'foobar',
+          },
+          value: {
+            token: { type: TokenType.INT, literal: '838383' },
+            value: '838383',
+          },
+        },
+      ]
+      expectedResults.forEach((expectedResult, index) => {
+        const statement = program.statements[index] as LetStatement
+        const expected = expectedResult
+        expect(statement.token).toEqual(expected.token)
+        expect(statement.name.token).toEqual(expected.name.token)
+        expect(statement.name.value).toEqual(expected.name.value)
+        expect(statement.value!.token).toEqual(expected.value.token)
+      })
     })
   })
 })


### PR DESCRIPTION
## このPR

issue #11 に関連してletの構文解析をした時のASTが把握できるようにテストケースを追加

```typescript
    const input = `
    let x = 5;
    let y = 10;
    let foobar = 838383;`
```

ASTは以下
```typescript

    {
      token: { type: TokenType.LET, literal: "let" },
      name: {
        token: { type: TokenType.IDENT, literal: "x" },
        value: "x",
      },
      value: {
        token: { type: TokenType.INT, literal: "5" },
        value: "5",
      },
    },
    {
      token: { type: TokenType.LET, literal: "let" },
      name: {
        token: { type: TokenType.IDENT, literal: "y" },
        value: "y",
      },
      value: {
        token: { type: TokenType.INT, literal: "10" },
        value: "10",
      },
    },
    {
      token: { type: TokenType.LET, literal: "let" },
      name: {
        token: { type: TokenType.IDENT, literal: "foobar" },
        value: "foobar",
      },
      value: {
        token: { type: TokenType.INT, literal: "838383" },
        value: "838383",
      },
    },

```
