### PR TITLE
テスト実行時に構文エラーがあった場合にデバッグしやすいようにメソッド追加

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,7 @@ export class Parser {
   private lexer: Lexer
   private currentToken!: Token
   private peekToken!: Token
+  private errors: string[] = [] // エラーメッセージを保持するための
 
   constructor(lexer: Lexer) {
     this.lexer = lexer
@@ -75,6 +76,7 @@ export class Parser {
       this.nextToken()
       return true
     } else {
+      this.peekError(tokenType)
       return false
     }
   }
@@ -82,7 +84,17 @@ export class Parser {
   private curTokenIs(tokenType: TokenType) {
     return this.currentToken.type === tokenType
   }
+
   private peekTokenIs(tokenType: TokenType) {
     return this.peekToken.type === tokenType
+  }
+
+  private peekError(expectedType: TokenType): void {
+    const msg = `expected next token to be ${expectedType}, got ${this.peekToken.type} instead`
+    this.errors.push(msg)
+  }
+
+  public getErrors(): string[] {
+    return this.errors
   }
 }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -5,6 +5,16 @@ import { LetStatement, Program } from '../src/ast'
 import type { Statement } from '../src/ast'
 import { TokenType } from 'src/token'
 
+const checkParseErrors = (parser: Parser) => {
+  const errors = parser.getErrors()
+  if (errors.length === 0) return
+
+  errors.forEach((error) => {
+    console.error(`Parser error: "${error}"`)
+  })
+
+  throw new Error(`Parse failed with ${errors.length} error(s)`)
+}
 describe('Parser', () => {
   describe('let', () => {
     const input = `
@@ -14,6 +24,7 @@ describe('Parser', () => {
     const lexer = new Lexer(input)
     const parser = new Parser(lexer)
     const program: Program | null = parser.parseProgram()
+    checkParseErrors(parser)
 
     it('program not to be null', () => {
       expect(program).not.toBeNull()


### PR DESCRIPTION
## このPR

issue #11 の関連作業